### PR TITLE
authentication as-needed

### DIFF
--- a/src/api/interfaces.ts
+++ b/src/api/interfaces.ts
@@ -174,8 +174,8 @@ export interface ApiResponse<T> {
 }
 
 export interface AuthenticatedRequest {
-    access_token: string;
-    api_key: string;
+    access_token?: string;
+    key?: string;
 }
 
 export interface QuestionRequest {

--- a/src/server/MCPServer.ts
+++ b/src/server/MCPServer.ts
@@ -10,6 +10,7 @@ import {
 import { StackExchangeApiClient } from '../api/stackexchange.js';
 import { Logger } from '../utils/logger.js';
 import { BaseTool } from '../tools/base-tool.js';
+import { AuthBaseTool } from '../tools/auth-base-tool.js';
 import { UserTools } from '../tools/users.js';
 import { QuestionTools } from '../tools/questions.js';
 import { AnswerTools } from '../tools/answers.js';
@@ -48,15 +49,15 @@ export class StackExchangeMCPServer {
         };
 
         const authService = AuthService.getInstance(authConfig);
-
+        const args: ConstructorParameters<typeof AuthBaseTool> = [authService, this.apiClient, this.logger];
         this.tools = [
-            new UserTools(this.apiClient, this.logger),
-            new QuestionTools(this.apiClient, this.logger),
-            new AnswerTools(this.apiClient, this.logger),
-            new CommentTools(this.apiClient, this.logger),
-            new TagTools(this.apiClient, this.logger),
-            new PostTools(this.apiClient, this.logger),
-            new WriteTools(this.apiClient, authService, this.logger),
+            new UserTools(...args),
+            new QuestionTools(...args),
+            new AnswerTools(...args),
+            new CommentTools(...args),
+            new TagTools(...args),
+            new PostTools(...args),
+            new WriteTools(...args),
             new DebugTools(this.logger)
         ];
         console.error('[DEBUG] Tools initialized');
@@ -106,7 +107,7 @@ export class StackExchangeMCPServer {
 
     private setupToolHandlers() {
         console.error('[DEBUG] Setting up tool handlers');
-        
+
         // List available tools
         this.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             console.error('[DEBUG] Handling ListTools request:', JSON.stringify(request, null, 2));

--- a/src/tools/answers.ts
+++ b/src/tools/answers.ts
@@ -1,17 +1,11 @@
 // src/tools/answers.ts
-import { BaseTool, ToolDefinition } from './base-tool.js';
-import { StackExchangeApiClient } from '../api/stackexchange.js';
+import { AuthBaseTool } from './auth-base-tool.js';
+import { ToolDefinition } from './base-tool.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { Logger } from '../utils/logger.js';
 
-export class AnswerTools extends BaseTool {
-    private apiClient: StackExchangeApiClient;
-    private logger: Logger;
-
-    constructor(apiClient: StackExchangeApiClient, logger: Logger) {
-        super();
-        this.apiClient = apiClient;
-        this.logger = logger;
+export class AnswerTools extends AuthBaseTool {
+    constructor(...args: ConstructorParameters<typeof AuthBaseTool>) {
+        super(...args);
     }
 
     getToolDefinitions(): ToolDefinition[] {
@@ -73,7 +67,7 @@ export class AnswerTools extends BaseTool {
         ];
     }
 
-    async handleToolCall(
+    protected async handleAuthenticatedToolCall(
         toolName: string,
         args: Record<string, any>
     ): Promise<{ content: any[] }> {

--- a/src/tools/auth-base-tool.ts
+++ b/src/tools/auth-base-tool.ts
@@ -3,15 +3,19 @@ import { BaseTool } from './base-tool.js';
 import { AuthService } from '../auth/auth-service.js';
 import { AuthState } from '../auth/auth-config.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { StackExchangeApiClient } from '../api/stackexchange.js';
 import { Logger } from '../utils/logger.js';
+import { AuthenticatedRequest } from '../api/interfaces.js';
 
 export abstract class AuthBaseTool extends BaseTool {
     protected authService: AuthService;
     protected logger: Logger;
+    protected apiClient: StackExchangeApiClient;
 
-    constructor(authService: AuthService, logger: Logger) {
+    constructor(authService: AuthService, apiClient: StackExchangeApiClient, logger: Logger) {
         super();
         this.authService = authService;
+        this.apiClient = apiClient;
         this.logger = logger;
     }
 
@@ -44,23 +48,32 @@ export abstract class AuthBaseTool extends BaseTool {
 
         // A tool requires auth if it has access_token or api_key in its required parameters
         const required = Array.isArray(schema.required) ? schema.required : [];
-        return required.includes('access_token') || required.includes('api_key');
+        return required.includes('access_token') || required.includes('api_key') || toolName === 'add_comment';
     }
 
     async handleToolCall(
         toolName: string,
         args: Record<string, any>
     ): Promise<{ content: any[] }> {
-        if (this.requiresAuth(toolName)) {
+        if (this.requiresAuth(toolName) || this.apiClient.getQuota() < 5) {
+            // Ensure auth is set up for required operations
             const authState = await this.ensureAuth();
             const config = this.authService.getConfig();
-
-            // Inject auth parameters
-            args = {
-                ...args,
-                access_token: authState.accessToken,
-                api_key: config.apiKey
-            };
+            if (config.apiKey) {
+                const auth: AuthenticatedRequest = {
+                    key: config.apiKey
+                };
+                if (authState.accessToken) {
+                    auth.access_token = authState.accessToken;
+                }
+                // Inject auth parameters
+                this.apiClient.setAuth(auth);
+            } else {
+                this.logger.warn(`low remaining quota of requests (${this.apiClient.getQuota()}) but no api key configured`);
+                this.apiClient.setAuth(null);
+            }
+        } else {
+            this.apiClient.setAuth(null);
         }
 
         return this.handleAuthenticatedToolCall(toolName, args);

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -1,17 +1,11 @@
 // src/tools/comments.ts
-import { BaseTool, ToolDefinition } from './base-tool.js';
-import { StackExchangeApiClient } from '../api/stackexchange.js';
+import { AuthBaseTool } from './auth-base-tool.js';
+import { ToolDefinition } from './base-tool.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { Logger } from '../utils/logger.js';
 
-export class CommentTools extends BaseTool {
-    private apiClient: StackExchangeApiClient;
-    private logger: Logger;
-
-    constructor(apiClient: StackExchangeApiClient, logger: Logger) {
-        super();
-        this.apiClient = apiClient;
-        this.logger = logger;
+export class CommentTools extends AuthBaseTool {
+    constructor(...args: ConstructorParameters<typeof AuthBaseTool>) {
+        super(...args);
     }
 
     getToolDefinitions(): ToolDefinition[] {
@@ -73,7 +67,7 @@ export class CommentTools extends BaseTool {
         ];
     }
 
-    async handleToolCall(
+    protected async handleAuthenticatedToolCall(
         toolName: string,
         args: Record<string, any>
     ): Promise<{ content: any[] }> {

--- a/src/tools/questions.ts
+++ b/src/tools/questions.ts
@@ -1,17 +1,11 @@
 // src/tools/questions.ts
-import { BaseTool, ToolDefinition } from './base-tool.js';
-import { StackExchangeApiClient } from '../api/stackexchange.js';
+import { AuthBaseTool } from './auth-base-tool.js';
+import { ToolDefinition } from './base-tool.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { Logger } from '../utils/logger.js';
 
-export class QuestionTools extends BaseTool {
-    private apiClient: StackExchangeApiClient;
-    private logger: Logger;
-
-    constructor(apiClient: StackExchangeApiClient, logger: Logger) {
-        super();
-        this.apiClient = apiClient;
-        this.logger = logger;
+export class QuestionTools extends AuthBaseTool {
+    constructor(...args: ConstructorParameters<typeof AuthBaseTool>) {
+        super(...args);
     }
 
     getToolDefinitions(): ToolDefinition[] {
@@ -295,7 +289,7 @@ export class QuestionTools extends BaseTool {
         ];
     }
 
-    async handleToolCall(
+    protected async handleAuthenticatedToolCall(
         toolName: string,
         args: Record<string, any>
     ): Promise<{ content: any[] }> {

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -1,17 +1,11 @@
 // src/tools/tags.ts
-import { BaseTool, ToolDefinition } from './base-tool.js';
-import { StackExchangeApiClient } from '../api/stackexchange.js';
+import { AuthBaseTool } from './auth-base-tool.js';
+import { ToolDefinition } from './base-tool.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { Logger } from '../utils/logger.js';
 
-export class TagTools extends BaseTool {
-    private apiClient: StackExchangeApiClient;
-    private logger: Logger;
-
-    constructor(apiClient: StackExchangeApiClient, logger: Logger) {
-        super();
-        this.apiClient = apiClient;
-        this.logger = logger;
+export class TagTools extends AuthBaseTool {
+    constructor(...args: ConstructorParameters<typeof AuthBaseTool>) {
+        super(...args);
     }
 
     getToolDefinitions(): ToolDefinition[] {
@@ -113,7 +107,7 @@ export class TagTools extends BaseTool {
         ];
     }
 
-    async handleToolCall(
+    protected async handleAuthenticatedToolCall(
         toolName: string,
         args: Record<string, any>
     ): Promise<{ content: any[] }> {

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -1,17 +1,11 @@
 // src/tools/users.ts
-import { BaseTool, ToolDefinition } from './base-tool.js';
-import { StackExchangeApiClient } from '../api/stackexchange.js';
+import { AuthBaseTool } from './auth-base-tool.js';
+import { ToolDefinition } from './base-tool.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { Logger } from '../utils/logger.js';
 
-export class UserTools extends BaseTool {
-    private apiClient: StackExchangeApiClient;
-    private logger: Logger;
-
-    constructor(apiClient: StackExchangeApiClient, logger: Logger) {
-        super();
-        this.apiClient = apiClient;
-        this.logger = logger;
+export class UserTools extends AuthBaseTool {
+    constructor(...args: ConstructorParameters<typeof AuthBaseTool>) {
+        super(...args);
     }
 
     getToolDefinitions(): ToolDefinition[] {
@@ -38,7 +32,7 @@ export class UserTools extends BaseTool {
         ];
     }
 
-    async handleToolCall(
+    protected async handleAuthenticatedToolCall(
         toolName: string,
         args: Record<string, any>
     ): Promise<{ content: any[] }> {

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -7,11 +7,8 @@ import { AuthService } from '../auth/auth-service.js';
 import { ToolDefinition } from './base-tool.js';
 
 export class WriteTools extends AuthBaseTool {
-    private apiClient: StackExchangeApiClient;
-
-    constructor(apiClient: StackExchangeApiClient, authService: AuthService, logger: Logger) {
-        super(authService, logger);
-        this.apiClient = apiClient;
+    constructor(...args: ConstructorParameters<typeof AuthBaseTool>) {
+        super(...args);
     }
 
     getToolDefinitions(): ToolDefinition[] {
@@ -257,10 +254,6 @@ export class WriteTools extends AuthBaseTool {
     ): Promise<{ content: any[] }> {
         try {
             const options = { site: args.site };
-            const auth = {
-                access_token: args.access_token,
-                api_key: args.api_key
-            };
 
             switch (toolName) {
                 case 'add_question': {
@@ -269,7 +262,7 @@ export class WriteTools extends AuthBaseTool {
                         body: args.body,
                         tags: args.tags
                     };
-                    const result = await this.apiClient.addQuestion(question, auth, options);
+                    const result = await this.apiClient.addQuestion(question, options);
                     return {
                         content: [{
                             type: 'text',
@@ -285,7 +278,7 @@ export class WriteTools extends AuthBaseTool {
                         tags: args.tags,
                         comment: args.comment
                     };
-                    const result = await this.apiClient.editQuestion(args.question_id, edit, auth, options);
+                    const result = await this.apiClient.editQuestion(args.question_id, edit, options);
                     return {
                         content: [{
                             type: 'text',
@@ -295,7 +288,7 @@ export class WriteTools extends AuthBaseTool {
                 }
 
                 case 'delete_question': {
-                    await this.apiClient.deleteQuestion(args.question_id, auth, options);
+                    await this.apiClient.deleteQuestion(args.question_id, options);
                     return {
                         content: [{
                             type: 'text',
@@ -309,7 +302,7 @@ export class WriteTools extends AuthBaseTool {
                         body: args.body,
                         comment: args.comment
                     };
-                    const result = await this.apiClient.addAnswer(args.question_id, answer, auth, options);
+                    const result = await this.apiClient.addAnswer(args.question_id, answer, options);
                     return {
                         content: [{
                             type: 'text',
@@ -319,7 +312,7 @@ export class WriteTools extends AuthBaseTool {
                 }
 
                 case 'delete_answer': {
-                    await this.apiClient.deleteAnswer(args.answer_id, auth, options);
+                    await this.apiClient.deleteAnswer(args.answer_id, options);
                     return {
                         content: [{
                             type: 'text',
@@ -329,7 +322,7 @@ export class WriteTools extends AuthBaseTool {
                 }
 
                 case 'accept_answer': {
-                    const result = await this.apiClient.acceptAnswer(args.answer_id, auth, options);
+                    const result = await this.apiClient.acceptAnswer(args.answer_id, options);
                     return {
                         content: [{
                             type: 'text',
@@ -339,7 +332,7 @@ export class WriteTools extends AuthBaseTool {
                 }
 
                 case 'undo_accept_answer': {
-                    const result = await this.apiClient.undoAcceptAnswer(args.answer_id, auth, options);
+                    const result = await this.apiClient.undoAcceptAnswer(args.answer_id, options);
                     return {
                         content: [{
                             type: 'text',
@@ -349,7 +342,7 @@ export class WriteTools extends AuthBaseTool {
                 }
 
                 case 'recommend_answer': {
-                    const result = await this.apiClient.recommendAnswer(args.answer_id, auth, options);
+                    const result = await this.apiClient.recommendAnswer(args.answer_id, options);
                     return {
                         content: [{
                             type: 'text',
@@ -359,7 +352,7 @@ export class WriteTools extends AuthBaseTool {
                 }
 
                 case 'undo_recommend_answer': {
-                    const result = await this.apiClient.undoRecommendAnswer(args.answer_id, auth, options);
+                    const result = await this.apiClient.undoRecommendAnswer(args.answer_id, options);
                     return {
                         content: [{
                             type: 'text',
@@ -373,7 +366,7 @@ export class WriteTools extends AuthBaseTool {
                         body: args.body,
                         comment: args.comment
                     };
-                    const result = await this.apiClient.addAnswerSuggestedEdit(args.answer_id, edit, auth, options);
+                    const result = await this.apiClient.addAnswerSuggestedEdit(args.answer_id, edit, options);
                     return {
                         content: [{
                             type: 'text',


### PR DESCRIPTION
- Now works out of the box (no environment required), using the free daily quota of 300 requests
- If an API key is set, it's used for authenticated requests (as it is now) but gets used automatically as soon as the remaining free quota of requests drops below 5. (up to 10.000 authenticated requests are allowed per day)
- If a clientId, scope and redirectUri are set, then the oAuth workflow is used according to the same heuristics
    
1. A new `SimpleAuthService` is created and the AuthService is reimplemented in consequence
2. ALl tool' classes extend the AuthBaseTool which provides conditional authentication.
3. Care has been made to wrap arguments passed-on MCPServer -> <Tool> -> AuthBaseTool
4. setAuth() is a method of the API client. Before each request, AuthBaseTool chooses whether authentication is needed or not (based on individual tool requirement but also quota). Allows for future extension/fallback mechanisms.
5. Tools still individually enforce authentication based on the "access_token" / "api_key" "required" field which is left untouched

> (173 insertions(+), 168 deletions(-), not accounting for the new `SimpleAuthService`)

fix #5